### PR TITLE
Add prometheus-client hooks

### DIFF
--- a/include/mgos_mqtt.h
+++ b/include/mgos_mqtt.h
@@ -12,7 +12,6 @@
 
 #ifndef CS_FW_SRC_MGOS_MQTT_H_
 #define CS_FW_SRC_MGOS_MQTT_H_
-
 #include <stdbool.h>
 
 #include "mgos_features.h"


### PR DESCRIPTION
As discussed, a proof of concept of the `prometheus-metrics` library. This PR is non-intrusive, and gates functionality on the presence of `-DMGOS_HAVE_PROMETHEUS_METRICS=1`, which will be invoked if the user adds `prometheus-metrics` to their `mos.yml` file. Users who do not have this library in their manifest will not see changes in behavior.

The PR will register a callback which will output the MQTT specific metrics.