### PR TITLE
Add support for setting retained flag of last will

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -26,6 +26,7 @@ config_schema:
   - ["mqtt.keep_alive", "i", 60, {title: "Keep alive interval"}]
   - ["mqtt.will_topic", "s", "", {title: "Will topic"}]
   - ["mqtt.will_message", "s", "", {title: "Will message"}]
+  - ["mqtt.will_retain", "b", false, {title: "Will retain flag"}]
   - ["mqtt.max_qos", "i", 2, {title: "Limit QoS of outgoing messages to at most this"}]
   - ["mqtt.recv_mbuf_limit", "i", 3072, {title: "Limit recv buffer size"}]
   - ["debug.stdout_topic", "s", "", {title: "MQTT topic to publish STDOUT to"}]

--- a/src/mgos_mqtt.c
+++ b/src/mgos_mqtt.c
@@ -128,6 +128,9 @@ static void mgos_mqtt_ev(struct mg_connection *nc, int ev, void *ev_data,
       if (mgos_sys_config_get_mqtt_clean_session()) {
         opts.flags |= MG_MQTT_CLEAN_SESSION;
       }
+      if (mgos_sys_config_get_mqtt_will_retain()) {
+        opts.flags |= MG_MQTT_WILL_RETAIN;
+      }
       opts.keep_alive = mgos_sys_config_get_mqtt_keep_alive();
       opts.will_topic = mgos_sys_config_get_mqtt_will_topic();
       opts.will_message = mgos_sys_config_get_mqtt_will_message();


### PR DESCRIPTION
The Last Will and Testament feature of MQTT combined with retained messages are commonly used for offline detection.

This allows setting of the LWT message as a retained message.