### PR TITLE
Add handling to allow for passing numeric value to ffi publish

### DIFF
--- a/mjs_fs/api_mqtt.js
+++ b/mjs_fs/api_mqtt.js
@@ -39,6 +39,7 @@ let MQTT = {
   // }, null);
   // ```
   pub: function(t, m, qos, retain) {
+    qos = qos || 0;
     let message = typeof m === "number" ? JSON.stringify( m ) : m;
     return this._pub(t, message, message.length, qos, retain || false);
   },

--- a/mjs_fs/api_mqtt.js
+++ b/mjs_fs/api_mqtt.js
@@ -39,8 +39,8 @@ let MQTT = {
   // }, null);
   // ```
   pub: function(t, m, qos, retain) {
-    qos = qos || 0;
-    return this._pub(t, m, m.length, qos, retain || false);
+    let message = typeof m === "number" ? JSON.stringify( m ) : m;
+    return this._pub(t, message, message.length, qos, retain || false);
   },
 
   // ## **`MQTT.setEventHandler(handler, userdata)`**


### PR DESCRIPTION
mJS throws an error if you pass a numeric value to ffi publish function, this checks `typeof` before calling `this._pub` and uses `JSON.stringify` to convert number to string