### PR TITLE
Return packet id when successfully publish a message

### DIFF
--- a/include/mgos_mqtt.h
+++ b/include/mgos_mqtt.h
@@ -82,10 +82,10 @@ bool mgos_mqtt_global_is_connected(void);
 
 /*
  * Publish message to the configured MQTT server, to the given MQTT topic.
- * Return value will be true if there is a connection to the server and the
- * message has been queued for sending. In case of QoS 1 return value does
- * not indicate that PUBACK has been received; there is currently no way to
- * check for that.
+ * Return value will be the packet id (> 0) if there is a connection to the server and the
+ * message has been queued for sending. In case no connection is available, 0 is returned.
+ * In case of QoS 1 return value does not indicate that PUBACK has been received; 
+ * there is currently no way to check for that.
  */
 uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len, int qos,
                    bool retain);

--- a/include/mgos_mqtt.h
+++ b/include/mgos_mqtt.h
@@ -87,13 +87,13 @@ bool mgos_mqtt_global_is_connected(void);
  * not indicate that PUBACK has been received; there is currently no way to
  * check for that.
  */
-bool mgos_mqtt_pub(const char *topic, const void *message, size_t len, int qos,
+uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len, int qos,
                    bool retain);
 
 /* Variant of mgos_mqtt_pub for publishing a JSON-formatted string */
-bool mgos_mqtt_pubf(const char *topic, int qos, bool retain,
+uint16_t mgos_mqtt_pubf(const char *topic, int qos, bool retain,
                     const char *json_fmt, ...);
-bool mgos_mqtt_pubv(const char *topic, int qos, bool retain,
+uint16_t mgos_mqtt_pubv(const char *topic, int qos, bool retain,
                     const char *json_fmt, va_list ap);
 
 /*

--- a/include/mgos_mqtt.h
+++ b/include/mgos_mqtt.h
@@ -82,19 +82,19 @@ bool mgos_mqtt_global_is_connected(void);
 
 /*
  * Publish message to the configured MQTT server, to the given MQTT topic.
- * Return value will be the packet id (> 0) if there is a connection to the server and the
- * message has been queued for sending. In case no connection is available, 0 is returned.
- * In case of QoS 1 return value does not indicate that PUBACK has been received; 
- * there is currently no way to check for that.
+ * Return value will be the packet id (> 0) if there is a connection to the
+ * server and the message has been queued for sending. In case no connection is
+ * available, 0 is returned. In case of QoS 1 return value does not indicate
+ * that PUBACK has been received; there is currently no way to check for that.
  */
-uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len, int qos,
-                   bool retain);
+uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len,
+                       int qos, bool retain);
 
 /* Variant of mgos_mqtt_pub for publishing a JSON-formatted string */
 uint16_t mgos_mqtt_pubf(const char *topic, int qos, bool retain,
-                    const char *json_fmt, ...);
+                        const char *json_fmt, ...);
 uint16_t mgos_mqtt_pubv(const char *topic, int qos, bool retain,
-                    const char *json_fmt, va_list ap);
+                        const char *json_fmt, va_list ap);
 
 /*
  * Callback signature for `mgos_mqtt_sub()` below.

--- a/src/mgos_mqtt.c
+++ b/src/mgos_mqtt.c
@@ -525,7 +525,7 @@ uint16_t mgos_mqtt_pubf(const char *topic, int qos, bool retain,
 
 uint16_t mgos_mqtt_pubv(const char *topic, int qos, bool retain,
                     const char *json_fmt, va_list ap) {
-  uint16_t res = false;
+  uint16_t res = 0;
   char *msg = json_vasprintf(json_fmt, ap);
   if (msg != NULL) {
     res = mgos_mqtt_pub(topic, msg, strlen(msg), qos, retain);

--- a/src/mgos_mqtt.c
+++ b/src/mgos_mqtt.c
@@ -499,8 +499,8 @@ struct mg_connection *mgos_mqtt_get_global_conn(void) {
   return s_conn;
 }
 
-uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len, int qos,
-                   bool retain) {
+uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len,
+                       int qos, bool retain) {
   uint16_t packet_id = mgos_mqtt_get_packet_id();
   struct mg_connection *c = mgos_mqtt_get_global_conn();
   int flags = MG_MQTT_QOS(adjust_qos(qos));
@@ -514,7 +514,7 @@ uint16_t mgos_mqtt_pub(const char *topic, const void *message, size_t len, int q
 }
 
 uint16_t mgos_mqtt_pubf(const char *topic, int qos, bool retain,
-                    const char *json_fmt, ...) {
+                        const char *json_fmt, ...) {
   uint16_t res;
   va_list ap;
   va_start(ap, json_fmt);
@@ -524,7 +524,7 @@ uint16_t mgos_mqtt_pubf(const char *topic, int qos, bool retain,
 }
 
 uint16_t mgos_mqtt_pubv(const char *topic, int qos, bool retain,
-                    const char *json_fmt, va_list ap) {
+                        const char *json_fmt, va_list ap) {
   uint16_t res = 0;
   char *msg = json_vasprintf(json_fmt, ap);
   if (msg != NULL) {


### PR DESCRIPTION
With a `packet_id` the user is allowed to check if a specific message was correctly sent to a broker (QoS > 0). This could be done  in a custom event handler where, now, we can compare the returned `packet_id` with the one contained in `ev_data`.