### PR TITLE
Partial implementation of mgos_mqtt_unsub()

### DIFF
--- a/include/mgos_mqtt.h
+++ b/include/mgos_mqtt.h
@@ -97,6 +97,11 @@ typedef void (*sub_handler_t)(struct mg_connection *nc, const char *topic,
 void mgos_mqtt_sub(const char *topic, sub_handler_t, void *ud);
 
 /*
+ * Unsubscribe on a topic on a configured MQTT server.
+ */
+bool mgos_mqtt_unsub(const char *topic);
+
+/*
  * Returns number of pending bytes to send.
  */
 size_t mgos_mqtt_num_unsent_bytes(void);

--- a/include/mgos_mqtt_conn.h
+++ b/include/mgos_mqtt_conn.h
@@ -104,6 +104,11 @@ void mgos_mqtt_conn_sub(struct mgos_mqtt_conn *c, const char *topic, int qos,
                         mg_event_handler_t handler, void *user_data);
 
 /*
+ * Unsubscribe from a specific topic.
+ */
+bool mgos_mqtt_conn_unsub(struct mgos_mqtt_conn *c, const char *topic);
+
+/*
  * Returns number of pending bytes to send.
  */
 size_t mgos_mqtt_conn_num_unsent_bytes(struct mgos_mqtt_conn *c);

--- a/src/mgos_mqtt.c
+++ b/src/mgos_mqtt.c
@@ -149,6 +149,10 @@ void mgos_mqtt_sub(const char *topic, sub_handler_t handler, void *user_data) {
   mgos_mqtt_global_subscribe(mg_mk_str(topic), mqttsubtrampoline, sd);
 }
 
+bool mgos_mqtt_unsub(const char *topic) {
+  return mgos_mqtt_conn_unsub(s_conn, topic);
+}
+
 size_t mgos_mqtt_num_unsent_bytes(void) {
   return mgos_mqtt_conn_num_unsent_bytes(s_conn);
 }

--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -631,6 +631,24 @@ void mgos_mqtt_conn_sub(struct mgos_mqtt_conn *c, const char *topic, int qos,
   mgos_mqtt_conn_sub_s(c, mg_mk_str(topic), qos, handler, user_data);
 }
 
+bool mgos_mqtt_conn_unsub(struct mgos_mqtt_conn *c, const char *topic) {
+  struct mgos_mqtt_subscription *s;
+
+  SLIST_FOREACH(s, &c->subscriptions, next) {
+    if (0 == strcmp(s->topic.p, topic)) {
+      LOG(LL_INFO,
+          ("MQTT%d unsub %.*s", c->conn_id, (int) s->topic.len, s->topic.p));
+      // mg_mqtt_unsubscribe(c->nc, (char **)&topic, 1, mgos_mqtt_conn_get_packet_id(c));
+      SLIST_REMOVE(&c->subscriptions, s, mgos_mqtt_subscription, next);
+      mg_strfree(&s->topic);
+      free(s->user_data);
+      free(s);
+      return true;
+    }
+  }
+  return false;
+}
+
 size_t mgos_mqtt_conn_num_unsent_bytes(struct mgos_mqtt_conn *c) {
   size_t num_bytes = 0;
   if (c == NULL) return 0;


### PR DESCRIPTION
I have a need to dynamically add and remove subscriptions in Mongoose OS. In particular, if one creates an object and passes that as user_data to a `mgos_mqtt_sub()` call, and subsequently `free()` that object, any subsequent publication to the subscribed topic will cause a crash (because the handler's user_data is invalid).

So,  add the ability to `mgos_mqtt_unsub()`.
It removes the subscription from the mgos_mqtt_conn->subscriptions list, but does not yet call mg_mqtt_unsubscribe() because that causes SIGSEGV. PTAL