### PR TITLE
Finish mgos_mqtt_unsub() (see #19)

### DIFF
--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -638,7 +638,9 @@ bool mgos_mqtt_conn_unsub(struct mgos_mqtt_conn *c, const char *topic) {
     if (0 == strcmp(s->topic.p, topic)) {
       LOG(LL_INFO,
           ("MQTT%d unsub %.*s", c->conn_id, (int) s->topic.len, s->topic.p));
-      // mg_mqtt_unsubscribe(c->nc, (char **)&topic, 1, mgos_mqtt_conn_get_packet_id(c));
+      if (c->connected)
+        mg_mqtt_unsubscribe(c->nc, (char **) &topic, 1,
+                            mgos_mqtt_conn_get_packet_id(c));
       SLIST_REMOVE(&c->subscriptions, s, mgos_mqtt_subscription, next);
       mg_strfree(&s->topic);
       free(s->user_data);

--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -638,9 +638,10 @@ bool mgos_mqtt_conn_unsub(struct mgos_mqtt_conn *c, const char *topic) {
     if (0 == strcmp(s->topic.p, topic)) {
       LOG(LL_INFO,
           ("MQTT%d unsub %.*s", c->conn_id, (int) s->topic.len, s->topic.p));
-      if (c->connected)
+      if (c->connected) {
         mg_mqtt_unsubscribe(c->nc, (char **) &topic, 1,
                             mgos_mqtt_conn_get_packet_id(c));
+      }
       SLIST_REMOVE(&c->subscriptions, s, mgos_mqtt_subscription, next);
       mg_strfree(&s->topic);
       free(s->user_data);

--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -635,7 +635,7 @@ bool mgos_mqtt_conn_unsub(struct mgos_mqtt_conn *c, const char *topic) {
   struct mgos_mqtt_subscription *s;
 
   SLIST_FOREACH(s, &c->subscriptions, next) {
-    if (0 == strcmp(s->topic.p, topic)) {
+    if (0 == mg_vcmp(&s->topic, topic)) {
       LOG(LL_INFO,
           ("MQTT%d unsub %.*s", c->conn_id, (int) s->topic.len, s->topic.p));
       if (c->connected) {


### PR DESCRIPTION
In #19, I committed all the library cleanup for unsubscribes, but I fell short of calling `mg_mqtt_unsubscribe()` because it was causing a crash. See #19 for the debug and fix proposal.
This PR submits the fix.