### PR TITLE
Gracefully disconnect MQTT

### DIFF
--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -491,6 +491,7 @@ void mgos_mqtt_conn_disconnect(struct mgos_mqtt_conn *c) {
   c->reconnect_timeout_ms = -1;  // Prevent reconnect.
   if (c->nc != NULL) {
     mg_mqtt_disconnect(c->nc);
+    c->nc->flags |= MG_F_SEND_AND_CLOSE;
   }
 }
 

--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -489,9 +489,7 @@ bool mgos_mqtt_conn_connect(struct mgos_mqtt_conn *c) {
 void mgos_mqtt_conn_disconnect(struct mgos_mqtt_conn *c) {
   if (c == NULL) return;
   c->reconnect_timeout_ms = -1;  // Prevent reconnect.
-  if (c->nc != NULL) {
-    c->nc->flags |= MG_F_CLOSE_IMMEDIATELY;
-  }
+  mg_mqtt_disconnect(c->nc);
 }
 
 bool mgos_mqtt_conn_is_connected(struct mgos_mqtt_conn *c) {

--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -489,7 +489,9 @@ bool mgos_mqtt_conn_connect(struct mgos_mqtt_conn *c) {
 void mgos_mqtt_conn_disconnect(struct mgos_mqtt_conn *c) {
   if (c == NULL) return;
   c->reconnect_timeout_ms = -1;  // Prevent reconnect.
-  mg_mqtt_disconnect(c->nc);
+  if (c->nc != NULL) {
+    mg_mqtt_disconnect(c->nc);
+  }
 }
 
 bool mgos_mqtt_conn_is_connected(struct mgos_mqtt_conn *c) {


### PR DESCRIPTION
Rather than forcing the connection, use the mg_disconnect method.