### PR TITLE
Add check for null conn in unsunscribe.

### DIFF
--- a/src/mgos_mqtt_conn.c
+++ b/src/mgos_mqtt_conn.c
@@ -615,8 +615,9 @@ void mgos_mqtt_conn_sub(struct mgos_mqtt_conn *c, const char *topic, int qos,
 }
 
 bool mgos_mqtt_conn_unsub(struct mgos_mqtt_conn *c, const char *topic) {
-  struct mgos_mqtt_subscription *s;
+  if (c == NULL) return false;
 
+  struct mgos_mqtt_subscription *s;
   SLIST_FOREACH(s, &c->subscriptions, next) {
     if (0 == mg_vcmp(&s->topic, topic)) {
       LOG(LL_INFO,


### PR DESCRIPTION
This causes a coredump in our setup if mqtt is not enabled and we try to unsubscribe.